### PR TITLE
[로그인] 카카오 로그인 API

### DIFF
--- a/greeneeds/core/utils.py
+++ b/greeneeds/core/utils.py
@@ -1,0 +1,65 @@
+import jwt, requests
+
+from django.conf   import settings
+from django.http   import JsonResponse
+
+from users.models  import User
+
+def login_decorator(func):
+
+    def wrapper(self, request, *args, **kwargs):
+        try:
+            token         = request.headers.get("Authorization", None)
+            token_payload = jwt.decode(token, settings.SECRET_KEY, settings.ALGORITHM)
+            user          = User.objects.get(id=token_payload['user_id'])
+            request.user  = user
+
+            return func(self, request, *args, **kwargs) 
+
+        except jwt.DecodeError:
+            return JsonResponse({'message' : 'INVALID_USER'}, status=401)
+
+        except User.DoesNotExist:
+            return JsonResponse({'message' : 'INVALID_USER'}, status=401)
+
+        except KeyError:
+            return JsonResponse({'message' : 'KEY_ERROR'}, status=401)
+            
+    return wrapper
+
+class KakaoAPI:
+    def __init__(self,KAKAO_REST_API_KEY, KAKAO_REDIRECT_URI):
+        self.kakao_rest_api_key = KAKAO_REST_API_KEY
+        self.kakao_redirect_uri = KAKAO_REDIRECT_URI
+        self.access_token       = None
+
+    def get_kakao_token(self, code):
+        auth_code       = code
+        kakao_token_api = "https://kauth.kakao.com/oauth/token"
+        data            = {
+            "grant_type"      : 'authorization_code',
+            "client_id"       : self.kakao_rest_api_key,
+            "redirect_uri"    : self.kakao_redirect_uri,
+            "code"            : auth_code
+        }
+        headers  = {'Content-type' : 'application/x-www-form-urlencoded;charset=utf-8'}
+        response = requests.post(kakao_token_api, headers=headers, data=data, timeout=3)
+
+        if not response.ok:
+            return JsonResponse({'message' : 'INVALID_RESPONSE'}, status=401)
+
+        self.access_token = response.json().get('access_token')
+        return self.access_token
+        
+    def get_kakao_profile(self, access_token):
+        headers = {
+            "Authorization" : f'Bearer {access_token}',
+            "Content-type"  : "application/x-www-form-urlencoded;charset=utf-8"
+        }
+        
+        response = requests.post("https://kapi.kakao.com/v2/user/me", headers=headers)
+        
+        if not response.ok:
+            return JsonResponse({'message' : 'INVALID_RESPONSE'}, status=401)
+        
+        return response.json()

--- a/greeneeds/greeneeds/settings.py
+++ b/greeneeds/greeneeds/settings.py
@@ -1,6 +1,6 @@
 from pathlib     import Path
 
-from my_settings import SECRET_KEY, DATABASES
+from my_settings import SECRET_KEY, DATABASES, KAKAO_REST_API_KEY, KAKAO_REDIRECT_URI, ALGORITHM, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -136,3 +136,9 @@ CORS_ALLOW_HEADERS = (
 )
 
 APPEND_SLASH = False
+
+KAKAO_REST_API_KEY = KAKAO_REST_API_KEY
+KAKAO_REDIRECT_URI = KAKAO_REDIRECT_URI
+ALGORITHM          = ALGORITHM
+AWS_ACCESS_KEY_ID  = AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY = AWS_SECRET_ACCESS_KEY

--- a/greeneeds/greeneeds/urls.py
+++ b/greeneeds/greeneeds/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path, include
 
 urlpatterns = [
-path("projects", include("projects.urls"))
+    path("projects", include("projects.urls")),
+    path('users', include('users.urls'))
 ]

--- a/greeneeds/users/tests.py
+++ b/greeneeds/users/tests.py
@@ -1,3 +1,122 @@
-from django.test import TestCase
+import json
 
-# Create your tests here.
+import jwt
+from django.test import TestCase, Client
+from django.conf import settings
+
+from .models        import User
+from unittest.mock  import patch, MagicMock
+
+class test_KakaoSignin(TestCase):
+    def setUp(self):
+        User.objects.create(
+            id         = 1,
+            kakao_id   = 11223344,
+            email      = "asdfqwer@naver.com",
+            nickname   = "test"
+        )
+    
+    def tearDown(self):
+        User.objects.all().delete()
+
+    @patch("users.views.KakaoAPI")
+    def test_success_kakao_signinView_login(self, mocked_kakao):
+        client   = Client()
+
+        class MockedResponse:
+            def get_kakao_token(self, code):
+                return 'kakao_token'
+            
+            def get_kakao_profile(self, access_token):
+                return {
+                        "id" : 11223344,
+                        "kakao_account" : {
+                            "email"                 : "asdfqwer@naver.com",
+                            'has_email'             : True,
+                            'email_needs_agreement' : False, 
+                            'is_email_valid'        : True, 
+                            'is_email_verified'     : True, 
+
+                        },
+                        "properties" :{
+                            "nickname" : "test"
+                        }
+                    }
+
+        mocked_kakao.return_value = MockedResponse()
+        
+        body     = {"code" : "asdf112"}
+        response = client.post("/users/signin/kakao", json.dumps(body), content_type = 'application/json')
+        
+        access_token = jwt.encode({'user_id' : 1}, settings.SECRET_KEY, settings.ALGORITHM)
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'token' : access_token})
+
+    @patch("users.views.KakaoAPI")
+    def test_success_kakao_signinView_signup(self, mocked_kakao):
+        client   = Client()
+
+        class MockedResponse:
+            def get_kakao_token(self, code):
+                return 'kakao_token'
+            
+            def get_kakao_profile(self, access_token):
+                return {
+                        "id" : 11223345,
+                        "kakao_account" : {
+                            "email"                 : "ytuhjk@naver.com",
+                            'has_email'             : True,
+                            'email_needs_agreement' : False, 
+                            'is_email_valid'        : True, 
+                            'is_email_verified'     : True, 
+
+                        },
+                        "properties" :{
+                            "nickname" : "test2"
+                        }
+                    }
+
+        mocked_kakao.return_value = MockedResponse()
+        
+        body     = {"code" : "asdf122312"}
+        response = client.post("/users/signin/kakao", json.dumps(body), content_type = 'application/json')
+        
+        access_token = jwt.encode({'user_id' : 2}, settings.SECRET_KEY, settings.ALGORITHM)
+        
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json(), {'token' : access_token})
+
+    @patch("users.views.KakaoAPI")
+    def test_keyerror_kakao_signinView_login(self, mocked_kakao):
+        client   = Client()
+
+        class MockedResponse:
+            def get_kakao_token(self, code):
+                return 'kakao_token'
+            
+            def get_kakao_profile(self, access_token):
+                return {
+                        "id" : 11223345,
+                        "kakao_account" : {
+                            "email"                 : "ytuhjk@naver.com",
+                            'has_email'             : True,
+                            'email_needs_agreement' : False, 
+                            'is_email_valid'        : True, 
+                            'is_email_verified'     : True, 
+
+                        },
+                        "properties" :{
+                            "nickname" : "test2"
+                        }
+                    }
+
+        mocked_kakao.return_value = MockedResponse()
+        
+        body     = {"code1" : "asdf122312"}
+        response = client.post("/users/signin/kakao", json.dumps(body), content_type = 'application/json')
+        
+        access_token = jwt.encode({'user_id' : 2}, settings.SECRET_KEY, settings.ALGORITHM)
+        
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'MESSAGE' : 'KEY_ERROR'})

--- a/greeneeds/users/urls.py
+++ b/greeneeds/users/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from users.views import KakaoSigninView
+
+urlpatterns = [
+    path('/signin/kakao', KakaoSigninView.as_view()), 
+]

--- a/greeneeds/users/views.py
+++ b/greeneeds/users/views.py
@@ -1,3 +1,36 @@
-from django.shortcuts import render
+import json
 
-# Create your views here.
+import jwt
+from django.views import View
+from django.http  import JsonResponse
+from django.conf  import settings
+
+from core.utils   import KakaoAPI
+from users.models import User
+
+class KakaoSigninView(View):
+    def post(self, request):
+        try:
+            data = json.loads(request.body)
+            code = data['code']
+
+            kakao_api = KakaoAPI(settings.KAKAO_REST_API_KEY, settings.KAKAO_REDIRECT_URI)
+
+            kakao_token   = kakao_api.get_kakao_token(code)
+            kakao_profile = kakao_api.get_kakao_profile(kakao_token)
+
+            user, is_created = User.objects.get_or_create(
+                kakao_id = kakao_profile['id'],
+                defaults = {
+                    'email'    : kakao_profile['kakao_account']['email'],
+                    'nickname' : kakao_profile['properties']['nickname']
+                }
+            )
+
+            status_code = 201 if is_created else 200
+
+            access_token = jwt.encode({'user_id': user.id}, settings.SECRET_KEY, settings.ALGORITHM)
+            return JsonResponse({'token': access_token}, status=status_code)
+                
+        except KeyError:
+            return JsonResponse({'MESSAGE' : 'KEY_ERROR'}, status = 400)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
1. 카카오 로그인 API 연동하기
2. 로그인 views.py 만들기


<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. core/utils.py 내 카카오 로그인 API 만들기
- 프론트로부터 인가 코드 받아와서 카카오 토큰 요청하기
- 카카오 토큰으로 카카오 유저 정보 요청
2. users/views.py
- 인가 코드 받아서 카카오 로그인 API 호출
- 카카오 로그인 API로부터 유저 정보 받기
- 받은 유저 정보로부터 이미 회원이면 로그인 아니면 회원가입



<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 다른 플랫폼으로부터 API 요청 양식에 맞춰 요청
- 요청 양식을 보는 방법을 알게 됨

<br />

## :: 기타 질문 및 특이 사항
- 없음


## 카카오 로그인 API POSTMAN 캡쳐
<img width="1094" alt="스크린샷 2022-07-08 오후 2 22 38" src="https://user-images.githubusercontent.com/65996045/177923240-b4edaffd-67cd-4c7b-aa85-2a6db17f24c9.png">



